### PR TITLE
Add multiple gpus training support

### DIFF
--- a/model/BasicTrainer.py
+++ b/model/BasicTrainer.py
@@ -176,7 +176,11 @@ class Trainer(object):
             # save the best state
             if best_state == True:
                 self.logger.info('*********************************Current best model saved!')
-                best_model = copy.deepcopy(self.model.state_dict())
+                # Handle DataParallel wrapped models
+                if hasattr(self.model, 'module'):
+                    best_model = copy.deepcopy(self.model.module.state_dict())
+                else:
+                    best_model = copy.deepcopy(self.model.state_dict())
                 best_model_test = copy.deepcopy(self.model)
 
         training_time = time.time() - start_time
@@ -198,8 +202,13 @@ class Trainer(object):
 
 
     def save_checkpoint(self):
+        # Handle DataParallel wrapped models
+        if hasattr(self.model, 'module'):
+            model_state = self.model.module.state_dict()
+        else:
+            model_state = self.model.state_dict()
         state = {
-            'state_dict': self.model.state_dict(),
+            'state_dict': model_state,
             'optimizer': self.optimizer.state_dict(),
             'config': self.args
         }
@@ -212,7 +221,11 @@ class Trainer(object):
             check_point = torch.load(path)
             state_dict = check_point['state_dict']
             args = check_point['config']
-            model.load_state_dict(state_dict)
+            # Handle DataParallel wrapped models
+            if hasattr(model, 'module'):
+                model.module.load_state_dict(state_dict)
+            else:
+                model.load_state_dict(state_dict)
             model.to(args.device)
         model.eval()
         y_pred = []

--- a/model/Run.py
+++ b/model/Run.py
@@ -76,6 +76,11 @@ else:
     model = Network_Predict(args, args_predictor)
     model = model.to(args.device)
 
+# Multi-GPU support with DataParallel
+if torch.cuda.device_count() > 1:
+    print(f"Using {torch.cuda.device_count()} GPUs with DataParallel")
+    model = nn.DataParallel(model)
+
 if args.xavier:
     for p in model.parameters():
         if p.requires_grad==True:
@@ -159,7 +164,11 @@ elif args.mode == 'eval':
 elif args.mode == 'ori':
     trainer.train()
 elif args.mode == 'test':
-    model.load_state_dict(torch.load(log_dir + '/best_model.pth'))
+    # Handle DataParallel wrapped models
+    if hasattr(model, 'module'):
+        model.module.load_state_dict(torch.load(log_dir + '/best_model.pth'))
+    else:
+        model.load_state_dict(torch.load(log_dir + '/best_model.pth'))
     print("Load saved model")
     trainer.test(model, trainer.args, test_loader, scaler_data, trainer.logger)
 else:


### PR DESCRIPTION
Add GPUs pre-train support using DataParallel
  Run.py:
  - Wraps model in DataParallel when multiple GPUs are detected
  - Handles model loading for test mode with wrapped models
  
  BasicTrainer.py:
  - Saves unwrapped model state (via model.module) so checkpoints work with any GPU setup
  - Updated save_checkpoint() and test() to handle wrapped models 

  The code now auto-detects multiple GPUs and uses them.  Just run as usual and it will print "Using N GPUs 
  with DataParallel" when multiple GPUs are available.